### PR TITLE
selecting_distance_from adds distance to query results

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ You can also order the records based on the distance from a point
 Place.within_radius(100, -22.951916,-43.210487).order_by_distance(-22.951916,-43.210487)
 ```
 
+Select the distance from a point:
+```ruby
+point = [-22.951916, -43.210487]
+closest = Place.within_radius(100, *point).order_by_distance(*point).selecting_distance_from(*point).first
+closest.distance
+```
+
 ##Test Database
 
 To have earthdistance enabled when you load your database schema (as happens in rake db:test:prepare), you

--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -23,9 +23,21 @@ module ActiveRecordPostgresEarthdistance
       def order_by_distance lat, lng, order= "ASC"
         order("earth_distance(ll_to_earth(#{self.latitude_column}, #{self.longitude_column}), ll_to_earth(#{lat}, #{lng})) #{order}")
       end
-
     end
   end
+
+  module QueryMethods
+    def selecting_distance_from lat, lng, name="distance", include_default_columns=true
+      clone.tap do |relation|
+        values = []
+        values << relation.arel_table[Arel.star] if relation.select_values.empty? && include_default_columns
+        values << "earth_distance(ll_to_earth(#{self.latitude_column}, #{self.longitude_column}), ll_to_earth(#{lat}, #{lng})) as #{name}"
+        relation.select_values = values
+      end
+    end
+  end
+
 end
 
 ActiveRecord::Base.send :include, ActiveRecordPostgresEarthdistance::ActsAsGeolocated
+ActiveRecord::Relation.send :include, ActiveRecordPostgresEarthdistance::QueryMethods

--- a/spec/act_as_geolocated_spec.rb
+++ b/spec/act_as_geolocated_spec.rb
@@ -53,4 +53,25 @@ describe "ActiveRecord::Base.act_as_geolocated" do
       it{ should == [@place_2, @place_1] }
     end
   end
+
+  describe "#selecting_distance_from" do
+    let(:current_location){ {lat: nil, lng: nil, radius: nil} }
+    subject do
+      Place.
+        order_by_distance(current_location[:lat], current_location[:lng]).
+        selecting_distance_from(current_location[:lat], current_location[:lng]).
+        first.
+        try{|p| [p.data, p.distance.to_f] }
+    end
+    before(:all) do
+      @place = Place.create!(:data => 'Amsterdam', :lat => 52.370216, :lng => 4.895168) #Amsterdam
+    end
+    after(:all) do
+      @place.destroy
+    end
+    context "when selecting distance" do
+      let(:current_location){{lat: 52.229676, lng: 21.012229}} #Warsaw
+      it{ should == ["Amsterdam", 1095013.87438311] }
+    end
+  end
 end


### PR DESCRIPTION
query results can have a column reporting distance
from a specified point

(Search for N points of interest within a radius of R from a point, where each result record has a `distance` added, reporting distance from the query point.)
