### PR TITLE
Add the within_box method for querying against the bounding box only

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ You can also order the records based on the distance from a point
 Place.within_radius(100, -22.951916,-43.210487).order_by_distance(-22.951916,-43.210487)
 ```
 
+The `within_radius` query performs two checks: first against the *bounding box*, followed by computing the exact distance for
+all contained elements. The latter might be computationally expensive for big ranges.
+So if precision is not an issue but query speed is, you might want to query against the bounding box only:
+```ruby
+Place.within_box(1_000_000, -22.951916,-43.210487)
+```
+
 ##Test Database
 
 To have earthdistance enabled when you load your database schema (as happens in rake db:test:prepare), you

--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -14,10 +14,12 @@ module ActiveRecordPostgresEarthdistance
         end
       end
 
+      def within_box radius, lat, lng
+        where("ll_to_earth(#{self.latitude_column}, #{self.longitude_column}) <@ earth_box(ll_to_earth(?, ?), ?)", lat, lng, radius)
+      end
+
       def within_radius radius, lat, lng
-        where(["ll_to_earth(#{self.latitude_column}, #{self.longitude_column}) <@ earth_box(ll_to_earth(?, ?), ?)" +
-               "AND earth_distance(ll_to_earth(#{self.latitude_column}, #{self.longitude_column}), ll_to_earth(?, ?)) <= ?",
-               lat, lng, radius, lat, lng, radius])
+        within_box(radius, lat, lng).where("earth_distance(ll_to_earth(#{self.latitude_column}, #{self.longitude_column}), ll_to_earth(?, ?)) <= ?", lat, lng, radius)
       end
 
       def order_by_distance lat, lng, order= "ASC"

--- a/spec/act_as_geolocated_spec.rb
+++ b/spec/act_as_geolocated_spec.rb
@@ -1,6 +1,46 @@
 require 'spec_helper'
 
 describe "ActiveRecord::Base.act_as_geolocated" do
+  describe "#within_box" do
+    let(:test_data) { { lat: nil, lng: nil, radius: nil } }
+
+    subject { Place.within_box(test_data[:radius], test_data[:lat], test_data[:lng]) }
+
+    before(:all) { @place = Place.create!(:lat => -30.0277041, :lng => -51.2287346) }
+    after(:all) { @place.destroy }
+
+    context "when query with null data" do
+      it { should be_empty }
+    end
+
+    context "when query for the exact same point with radius 0" do
+      let(:test_data) { { lat: -30.0277041, lng: -51.2287346 , radius: 0 } }
+
+      it { should == [@place] }
+    end
+
+    context "when query for place within the box" do
+      let(:test_data) { { radius: 4000000, lat: -27.5969039, lng: -48.5494544 } }
+
+      it { should == [@place] }
+    end
+
+    context "when query for place within the box, but outside the radius" do
+      let(:test_data) { { radius: 300000, lat: -27.5969039, lng: -48.5494544 } }
+
+      it "the place shouldn't be within the radius" do
+        Place.within_radius(test_data[:radius], test_data[:lat], test_data[:lng]).should be_empty
+      end
+
+      it { should == [@place] }
+    end
+
+    context "when query for place outside the box" do
+      let(:test_data) { { radius: 1000, lat: -27.5969039, lng: -48.5494544 } }
+      it { should be_empty }
+    end
+  end
+
   describe "#within_radius" do
     let(:test_data){ {lat: nil, lng: nil, radius: nil} }
     subject{ Place.within_radius(test_data[:radius], test_data[:lat], test_data[:lng]) }
@@ -28,6 +68,7 @@ describe "ActiveRecord::Base.act_as_geolocated" do
 
     context "when query for place outside the radius" do
       let(:test_data){ {radius: 1000, lat: -27.5969039, lng: -48.5494544} }
+      it{ should == [] }
     end
   end
 


### PR DESCRIPTION
We were working with big ranges (> 1500km) and noticed that computing the exact distance doesn't perform very well with a large dataset.
However, for such long distances, precision might not be an issue (at least it's not for us).
So this PR splits up the `within_radius` method in two separate scopes: one querying against the bounding box (`within_box`) and the other one computing the exact distance.
I've also written some tests.
Hope this fits to your lovely gem :dancers: 
