### PR TITLE
Rewrite gem to use Arel instead of concatenating strings

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -42,7 +42,7 @@ module ActiveRecordPostgresEarthdistance
       clone.tap do |relation|
         values = []
         values << relation.arel_table[Arel.star] if relation.select_values.empty? && include_default_columns
-        values << "earth_distance(ll_to_earth(#{self.quoted_table_name}.#{self.latitude_column}, #{self.quoted_table_name}.#{self.longitude_column}), ll_to_earth(#{lat}, #{lng})) as #{name}"
+        values << "earth_distance(ll_to_earth(#{self.latitude_column}, #{self.longitude_column}), ll_to_earth(#{lat}, #{lng})) as #{name}"
         relation.select_values = values
       end
     end

--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -2,9 +2,6 @@ module ActiveRecordPostgresEarthdistance
   module ActsAsGeolocated
     extend ActiveSupport::Concern
 
-    included do
-    end
-
     module ClassMethods
       def acts_as_geolocated(options = {})
         if table_exists?
@@ -14,16 +11,28 @@ module ActiveRecordPostgresEarthdistance
         end
       end
 
-      def within_box radius, lat, lng
-        where("ll_to_earth(#{self.latitude_column}, #{self.longitude_column}) <@ earth_box(ll_to_earth(?, ?), ?)", lat, lng, radius)
+      def within_box(radius, lat, lng)
+        earth_box = Arel::Nodes::NamedFunction.new('earth_box', [ll_to_earth_coords(lat, lng), radius])
+        where Arel::Nodes::InfixOperation.new('<@', ll_to_earth_columns, earth_box)
       end
 
-      def within_radius radius, lat, lng
-        within_box(radius, lat, lng).where("earth_distance(ll_to_earth(#{self.latitude_column}, #{self.longitude_column}), ll_to_earth(?, ?)) <= ?", lat, lng, radius)
+      def within_radius(radius, lat, lng)
+        earth_distance = Arel::Nodes::NamedFunction.new('earth_distance', [ll_to_earth_columns, ll_to_earth_coords(lat, lng)])
+        within_box(radius, lat, lng).where(Arel::Nodes::InfixOperation.new('<=', earth_distance, radius))
       end
 
-      def order_by_distance lat, lng, order= "ASC"
-        order("earth_distance(ll_to_earth(#{self.latitude_column}, #{self.longitude_column}), ll_to_earth(#{lat}, #{lng})) #{order}")
+      def order_by_distance(lat, lng, order = "ASC")
+        earth_distance = Arel::Nodes::NamedFunction.new('earth_distance', [ll_to_earth_columns, ll_to_earth_coords(lat, lng)])
+        order("#{earth_distance.to_sql} #{order.to_s}")
+      end
+
+      protected
+      def ll_to_earth_columns
+        Arel::Nodes::NamedFunction.new('ll_to_earth', [arel_table[self.latitude_column], arel_table[self.longitude_column]])
+      end
+
+      def ll_to_earth_coords lat, lng
+        Arel::Nodes::NamedFunction.new('ll_to_earth', [lat, lng])
       end
     end
   end
@@ -33,12 +42,11 @@ module ActiveRecordPostgresEarthdistance
       clone.tap do |relation|
         values = []
         values << relation.arel_table[Arel.star] if relation.select_values.empty? && include_default_columns
-        values << "earth_distance(ll_to_earth(#{self.latitude_column}, #{self.longitude_column}), ll_to_earth(#{lat}, #{lng})) as #{name}"
+        values << "earth_distance(ll_to_earth(#{self.quoted_table_name}.#{self.latitude_column}, #{self.quoted_table_name}.#{self.longitude_column}), ll_to_earth(#{lat}, #{lng})) as #{name}"
         relation.select_values = values
       end
     end
   end
-
 end
 
 ActiveRecord::Base.send :include, ActiveRecordPostgresEarthdistance::ActsAsGeolocated

--- a/spec/act_as_geolocated_spec.rb
+++ b/spec/act_as_geolocated_spec.rb
@@ -39,6 +39,21 @@ describe "ActiveRecord::Base.act_as_geolocated" do
       let(:test_data) { { radius: 1000, lat: -27.5969039, lng: -48.5494544 } }
       it { should be_empty }
     end
+
+    context "when joining tables that are also geoloacted" do
+      let(:test_data) { { radius: 1000, lat: -27.5969039, lng: -48.5494544 } }
+
+      subject { Place.within_box(test_data[:radius], test_data[:lat], test_data[:lng]) }
+
+      it "should work with objects having columns with the same name" do
+        expect { Place.joins(:events).within_radius(test_data[:radius], test_data[:lat], test_data[:lng]).to_a }.to_not raise_error
+
+      end
+
+      it "should work with nested associations" do
+        expect { Event.joins(:events).within_radius(test_data[:radius], test_data[:lat], test_data[:lng]).to_a }.to_not raise_error
+      end
+    end
   end
 
   describe "#within_radius" do

--- a/spec/fixtures/event.rb
+++ b/spec/fixtures/event.rb
@@ -1,0 +1,5 @@
+class Event < ActiveRecord::Base
+  acts_as_geolocated
+  belongs_to :place
+  has_many :events
+end

--- a/spec/fixtures/place.rb
+++ b/spec/fixtures/place.rb
@@ -1,3 +1,4 @@
 class Place < ActiveRecord::Base
   acts_as_geolocated
+  has_many :events
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,9 @@ RSpec.configure do |config|
         CREATE EXTENSION IF NOT EXISTS cube;
         CREATE EXTENSION IF NOT EXISTS earthdistance;
         DROP TABLE IF EXISTS places;
+        DROP TABLE IF EXISTS events;
         CREATE TABLE places (id serial PRIMARY KEY, data text, lat float8, lng float8);
+        CREATE TABLE events (id serial PRIMARY KEY, event_id integer, place_id integer, data text, lat float8, lng float8);
 }
     rescue Exception => e
       puts "Exception: #{e}"
@@ -39,8 +41,9 @@ RSpec.configure do |config|
       retry
     end
 
-    # Load model used in spec
+    # Load models used in spec
     require 'fixtures/place'
+    require 'fixtures/events'
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,7 @@ RSpec.configure do |config|
 
     # Load models used in spec
     require 'fixtures/place'
-    require 'fixtures/events'
+    require 'fixtures/event'
   end
 
 end


### PR DESCRIPTION
This pull request rewrites acts_as_geolocated methods to use Arel instead of concatenating strings together. This should prevent issues like #13 in the future and is less error-prone.

All tests have been checked and they are passing correctly.