### PR TITLE
Add method to drop index in migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,12 @@ Edit the created migration:
 
 ```ruby
 class AddIndexToPlaces < ActiveRecord::Migration
-  def change
+  def up
     add_earthdistance_index :places
+  end
+
+  def down
+    remove_earthdistance_index :places
   end
 end
 ```

--- a/lib/activerecord-postgres-earthdistance/activerecord.rb
+++ b/lib/activerecord-postgres-earthdistance/activerecord.rb
@@ -4,12 +4,13 @@ module ActiveRecord
   module ConnectionAdapters
     module SchemaStatements
 
-      # Installs hstore by creating the Postgres extension
-      # if it does not exist
-      #
       def add_earthdistance_index table_name, options = {}
         execute "CREATE INDEX %s_earthdistance_ix ON %s USING gist (ll_to_earth(%s, %s));" %
           [table_name, table_name, (options[:lat] || 'lat'), (options[:lng] || 'lng')]
+      end
+
+      def remove_earthdistance_index table_name
+        execute "DROP INDEX %s_earthdistance_ix;" % [table_name]
       end
     end
   end


### PR DESCRIPTION
While setting it up, I ran into an issue where I had to rollback the earthdistance migrations. This PR adds a method to drop the index so rollbacks can be performed cleanly. I tried using `add_index` as possible alternative to executing straight SQL so that it could be captured in `schema.rb`, but it wouldn't let me use `ll_to_earth(lat, lng)` as an argument because it doesn't match any column names. 

Thanks for this gem, it's been very useful. 