### PR TITLE
Fix #16 Error with Arel 6.0.0

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -32,7 +32,11 @@ module ActiveRecordPostgresEarthdistance
       end
 
       def ll_to_earth_coords lat, lng
-        Arel::Nodes::NamedFunction.new('ll_to_earth', [lat, lng])
+        if Arel::Nodes.respond_to?(:build_quoted) # for arel >= 6.0.0
+          Arel::Nodes::NamedFunction.new('ll_to_earth', [Arel::Nodes.build_quoted(lat), Arel::Nodes.build_quoted(lng)])
+        else
+          Arel::Nodes::NamedFunction.new('ll_to_earth', [lat, lng])
+        end
       end
     end
   end


### PR DESCRIPTION
Arel 6.0.0 had (obviously) undocumented change in how it handles NamedFunction. As you can see in rails/arel@93d72131b , everything that is not a very simple value has to be "quoted" (wrapped in `Arel::Nodes::Quoted`) to work properly. 

This pull request adds checking if the `Arel::Nodes.build_quoted` method is available and uses it if necessary. I don't think such a change requires a new test case but if you wish, I can add one.