### PR TITLE
Fix bug of query method: selecting_distance_from

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -37,8 +37,6 @@ module ActiveRecordPostgresEarthdistance
         joins(through_table).order("#{earth_distance.to_sql} #{order}")
       end
 
-      private
-
       def through_table_klass
         if through_table.present?
           reflections[through_table.to_s].klass
@@ -84,11 +82,12 @@ module ActiveRecordPostgresEarthdistance
   module QueryMethods
     def selecting_distance_from(lat, lng, name = "distance", include_default_columns = true)
       clone.tap do |relation|
+        relation.joins!(through_table)
         values = []
         if relation.select_values.empty? && include_default_columns
           values << relation.arel_table[Arel.star]
         end
-        values << Utils.earth_distance(self, lat, lng, name)
+        values << Utils.earth_distance(through_table_klass, lat, lng, name)
 
         relation.select_values = values
       end

--- a/spec/act_as_geolocated_spec.rb
+++ b/spec/act_as_geolocated_spec.rb
@@ -201,5 +201,24 @@ describe "ActiveRecord::Base.act_as_geolocated" do
       let(:current_location) { { lat: 52.229676, lng: 21.012229 } } # Warsaw
       it { should == ["Amsterdam", 1_095_013.87438311] }
     end
+
+    context "through table" do
+
+      subject { Job.all.selecting_distance_from(current_location[:lat], current_location[:lng]).first }
+
+      before(:all) do
+        @event = Event.create!(lat: -30.0277041, lng: -51.2287346)
+        @job = Job.create!(event: @event)
+      end
+
+      after(:all) do
+        @event.destroy
+        @job.destroy
+      end
+
+      context "when selecting distance" do
+        it { should respond_to :distance }
+      end
+    end
   end
 end


### PR DESCRIPTION
selecting_distance_from doesn't support through table

    class Address < ActiveRecord::Base
      acts_as_geolocated lat: 'lat', lng: 'lng'
    end

    class Shop < ActiveRecord::Base
      belongs_to :address
      acts_as_geolocated through: :address
    end


    [2] pry(main)> point = [-22.951916, -43.210487]
    => [-22.951916, -43.210487]

    [3] pry(main)> Shop.all.selecting_distance_from(*point).first
    Shop Load (3.3ms)  SELECT  "shops".*, earth_distance(ll_to_earth("shops"."latitude", "shops"."longitude"), ll_to_earth(-22.951916, -43.210487)) AS distance FROM "shops" ORDER BY "shops"."id" ASC LIMIT $1  [["LIMIT", 1]]
    ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column shops.latitude does not exist
