### PR TITLE
Don't acts_as_geolocated while running db migration

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -4,11 +4,15 @@ module ActiveRecordPostgresEarthdistance
 
     module ClassMethods
       def acts_as_geolocated(options = {})
-        cattr_accessor :latitude_column, :longitude_column, :through_table
-        self.latitude_column = options[:lat] || (column_names.include?("lat") ? "lat" : "latitude")
-        self.longitude_column = options[:lng] ||
-                                (column_names.include?("lng") ? "lng" : "longitude")
-        self.through_table = options[:through]
+        if table_exists?
+          cattr_accessor :latitude_column, :longitude_column, :through_table
+          self.latitude_column = options[:lat] || (column_names.include?("lat") ? "lat" : "latitude")
+          self.longitude_column = options[:lng] ||
+                                  (column_names.include?("lng") ? "lng" : "longitude")
+          self.through_table = options[:through]
+        else
+          puts "[WARNING] table #{table_name} doesn't exist, acts_as_geolocated won't work. Skip this warning if you are running db migration"
+        end
       end
 
       def within_box(radius, lat, lng)


### PR DESCRIPTION
When running `rails db:create db:migrate` for a new developer, will get error since db table has not been created.