### PR TITLE
acts_as_geolocated resuces from ActiveRecord::NoDatabaseError

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -13,6 +13,7 @@ module ActiveRecordPostgresEarthdistance
         else
           puts "[WARNING] table #{table_name} doesn't exist, acts_as_geolocated won't work. Skip this warning if you are running db migration"
         end
+      rescue ActiveRecord::NoDatabaseError
       end
 
       def within_box(radius, lat, lng)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,8 +12,8 @@ RSpec.configure do |config|
       ActiveRecord::Base.establish_connection(
         adapter: "postgresql",
         host: "localhost",
-        username: "postgres",
-        password: "postgres",
+        # username: "postgres",
+        # password: "postgres",
         port: 5432,
         database: "ar_pg_earthdistance_test"
       )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,8 +12,8 @@ RSpec.configure do |config|
       ActiveRecord::Base.establish_connection(
         adapter: "postgresql",
         host: "localhost",
-        # username: "postgres",
-        # password: "postgres",
+        username: "postgres",
+        password: "postgres",
         port: 5432,
         database: "ar_pg_earthdistance_test"
       )


### PR DESCRIPTION
In Rails 5, it's possible for acts_as_geolocated to get called when the application preloads, before the database has been created, when running `rails db:create`. When this happens, `table_exists?` throws ActiveRecord::NoDatabaseError and the task fails. Rescuing from this error lets the database creation task succeed.