### PR TITLE
replace table_exists? with data_source_exists?

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -5,7 +5,7 @@ module ActiveRecordPostgresEarthdistance
     module ClassMethods
       MILES_TO_METERS_FACTOR = 1609.344
       def acts_as_geolocated(options = {})
-        if table_exists?
+        if ActiveRecord::Base.connection.data_source_exists?(table_name)
           cattr_accessor :latitude_column, :longitude_column, :through_table, :distance_unit
           self.latitude_column = options[:lat] || (column_names.include?("lat") ? "lat" : "latitude")
           self.longitude_column = options[:lng] ||


### PR DESCRIPTION
Since Rails5, `table_exists?` only works for tables, which makes `acts_as_geolocated` fail on materialized views.

http://guides.rubyonrails.org/5_0_release_notes.html#active-record-deprecations