### PR TITLE
Allow strings as input to within_radius and within_box when distance unit is miles

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -19,7 +19,7 @@ module ActiveRecordPostgresEarthdistance
       end
 
       def within_box(radius, lat, lng)
-        radius = radius.try(:*, MILES_TO_METERS_FACTOR) if distance_unit === :miles
+        radius = radius.to_f * MILES_TO_METERS_FACTOR if distance_unit === :miles
         earth_box = Arel::Nodes::NamedFunction.new(
           "earth_box",
           [Utils.ll_to_earth_coords(lat, lng), Utils.quote_value(radius)]
@@ -35,7 +35,7 @@ module ActiveRecordPostgresEarthdistance
       end
 
       def within_radius(radius, lat, lng)
-        radius = radius.try(:*, MILES_TO_METERS_FACTOR) if distance_unit === :miles
+        radius = radius.to_f * MILES_TO_METERS_FACTOR if distance_unit === :miles
         earth_distance = Utils.earth_distance(through_table_klass, lat, lng)
         within_box(radius, lat, lng)
           .where(Arel::Nodes::InfixOperation.new("<=", earth_distance, Utils.quote_value(radius)))

--- a/spec/act_as_geolocated_spec.rb
+++ b/spec/act_as_geolocated_spec.rb
@@ -217,7 +217,6 @@ describe "ActiveRecord::Base.act_as_geolocated" do
     let(:test_data) { { lat: nil, lng: nil, radius: nil } }
     subject { Place.within_radius(test_data[:radius], test_data[:lat], test_data[:lng]) }
     before(:all) do
-      # Place.distance_unit = :miles
       Place.acts_as_geolocated distance_unit: :miles
       @place = Place.create!(lat: -30.0277041, lng: -51.2287346)
     end

--- a/spec/act_as_geolocated_spec.rb
+++ b/spec/act_as_geolocated_spec.rb
@@ -103,6 +103,12 @@ describe "ActiveRecord::Base.act_as_geolocated" do
       it { is_expected.to eq [@place] }
     end
 
+    context "when radius is a string" do
+      let(:test_data) { { radius: '2400', lat: -27.5969039, lng: -48.5494544 } }
+
+      it { is_expected.to eq [@place] }
+    end
+
     context "when query for place within the box, but outside the radius" do
       let(:test_data) { { radius: 186, lat: -27.5969039, lng: -48.5494544 } }
 
@@ -232,6 +238,11 @@ describe "ActiveRecord::Base.act_as_geolocated" do
 
     context "when query for place within radius" do
       let(:test_data) { { radius: 2400, lat: -27.5969039, lng: -48.5494544 } }
+      it { is_expected.to eq [@place] }
+    end
+
+    context "when radius is a string" do
+      let(:test_data) { { radius: '2400', lat: -27.5969039, lng: -48.5494544 } }
       it { is_expected.to eq [@place] }
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,8 +12,8 @@ RSpec.configure do |config|
       ActiveRecord::Base.establish_connection(
         adapter: "postgresql",
         host: "localhost",
-        username: "postgres",
-        password: "postgres",
+        # username: "postgres",
+        # password: "postgres",
         port: 5432,
         database: "ar_pg_earthdistance_test"
       )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,8 +12,8 @@ RSpec.configure do |config|
       ActiveRecord::Base.establish_connection(
         adapter: "postgresql",
         host: "localhost",
-        # username: "postgres",
-        # password: "postgres",
+        username: "postgres",
+        password: "postgres",
         port: 5432,
         database: "ar_pg_earthdistance_test"
       )


### PR DESCRIPTION
Convert radius input to float before multiplying. nil and non-numeric strings coerce to 0, so to_f is enough. Loosely typed languages are fun!