### PR TITLE
rescue PG::ConnectionBad

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -6,17 +6,20 @@ module ActiveRecordPostgresEarthdistance
 
     module ClassMethods  
       def acts_as_geolocated(options = {})
-        if table_exists?
-          cattr_accessor :latitude_column, :longitude_column, :through_table, :distance_unit
-          self.latitude_column = options[:lat] || (column_names.include?("lat") ? "lat" : "latitude")
-          self.longitude_column = options[:lng] ||
-                                  (column_names.include?("lng") ? "lng" : "longitude")
-          self.through_table = options[:through]
-          self.distance_unit = options[:distance_unit]
-        else
-          puts "[WARNING] table #{table_name} doesn't exist, acts_as_geolocated won't work. Skip this warning if you are running db migration"
+        begin
+          if table_exists?
+            cattr_accessor :latitude_column, :longitude_column, :through_table, :distance_unit
+            self.latitude_column = options[:lat] || (column_names.include?("lat") ? "lat" : "latitude")
+            self.longitude_column = options[:lng] ||
+                                    (column_names.include?("lng") ? "lng" : "longitude")
+            self.through_table = options[:through]
+            self.distance_unit = options[:distance_unit]
+          else
+            puts "[WARNING] table #{table_name} doesn't exist, acts_as_geolocated won't work. Skip this warning if you are running db migration"
+          end
+        rescue ActiveRecord::NoDatabaseError
+        rescue PG::ConnectionBad
         end
-      rescue ActiveRecord::NoDatabaseError
       end
 
       def within_box(radius, lat, lng)


### PR DESCRIPTION
PG:ConnectionBad is thrown if the database cannot be communicated with while using `0.17.1` of the pg gem (Rails/ActiveRecord 4.2).  This prevents `rake assets:precompile` from running successfully when a model utilizing `acts_as_geolocated` is loaded during asset compilation (Devise loads the user model, for example).

This became an issue for me on Heroku where I am using qgtunnel in my Procfile to route traffic through a proxy (i.e. the Procfile is only used when starting the server).  Since the proxy is not available during Heroku's bundle invocation the DB connection fails, which also causes asset compilation to fail.   