### PR TITLE
Use versioned migrations in Rails 5+

### DIFF
--- a/lib/activerecord-postgres-earthdistance/railties.rb
+++ b/lib/activerecord-postgres-earthdistance/railties.rb
@@ -32,7 +32,19 @@ class EarthDistance < Rails::Railtie
     end
 
     def create_migration_file
-      migration_template "setup_earthdistance.rb", "db/migrate/setup_earthdistance.rb"
+      migration_template "setup_earthdistance.rb", "db/migrate/setup_earthdistance.rb", migration_version: migration_version
+    end
+
+    private
+
+    def requires_migration_version?
+      Rails::VERSION::MAJOR >= 5
+    end
+
+    def migration_version
+      if requires_migration_version?
+        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+      end
     end
   end
 end

--- a/lib/templates/setup_earthdistance.rb
+++ b/lib/templates/setup_earthdistance.rb
@@ -1,4 +1,4 @@
-class SetupEarthdistance < ActiveRecord::Migration
+class SetupEarthdistance < ActiveRecord::Migration<%= migration_version %>
   def self.up
     execute "CREATE EXTENSION IF NOT EXISTS cube"
     execute "CREATE EXTENSION IF NOT EXISTS earthdistance"


### PR DESCRIPTION
Today I was adding this to a Rails 5.2 app and the install failed since there wasn't a version in the migration file. This change will detect which version of Rails you're on and add the version if it needs to.