### PR TITLE
Switch from Travis to GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,115 @@
+name: Test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gemfile: [
+          activerecord-4.2,
+          activerecord-5.0,
+          activerecord-5.1,
+          activerecord-5.2,
+          activerecord-6.0,
+          activerecord-6.1,
+          activerecord-7.0,
+        ]
+        ruby-version: [
+          '2.4',
+          '2.5',
+          '2.6',
+          '2.7',
+          '3.0',
+          '3.1',
+        ]
+        exclude:
+          - gemfile: activerecord-4.2
+            ruby-version: '2.5'
+          - gemfile: activerecord-4.2
+            ruby-version: '2.6'
+          - gemfile: activerecord-4.2
+            ruby-version: '2.7'
+          - gemfile: activerecord-4.2
+            ruby-version: '3.0'
+          - gemfile: activerecord-4.2
+            ruby-version: '3.1'
+
+          - gemfile: activerecord-5.0
+            ruby-version: '2.5'
+          - gemfile: activerecord-5.0
+            ruby-version: '2.6'
+          - gemfile: activerecord-5.0
+            ruby-version: '2.7'
+          - gemfile: activerecord-5.0
+            ruby-version: '3.0'
+          - gemfile: activerecord-5.0
+            ruby-version: '3.1'
+
+          - gemfile: activerecord-5.1
+            ruby-version: '2.6'
+          - gemfile: activerecord-5.1
+            ruby-version: '2.7'
+          - gemfile: activerecord-5.1
+            ruby-version: '3.0'
+          - gemfile: activerecord-5.1
+            ruby-version: '3.1'
+
+          - gemfile: activerecord-5.2
+            ruby-version: '2.6'
+          - gemfile: activerecord-5.2
+            ruby-version: '2.7'
+          - gemfile: activerecord-5.2
+            ruby-version: '3.0'
+          - gemfile: activerecord-5.2
+            ruby-version: '3.1'
+
+          - gemfile: activerecord-6.0
+            ruby-version: '2.4'
+          - gemfile: activerecord-6.0
+            ruby-version: '2.7'
+          - gemfile: activerecord-6.0
+            ruby-version: '3.0'
+          - gemfile: activerecord-6.0
+            ruby-version: '3.1'
+
+          - gemfile: activerecord-6.1
+            ruby-version: '2.4'
+
+          - gemfile: activerecord-7.0
+            ruby-version: '2.4'
+          - gemfile: activerecord-7.0
+            ruby-version: '2.5'
+          - gemfile: activerecord-7.0
+            ruby-version: '2.6'
+
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports: ["5432:5432"]
+
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Run tests
+      run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
-  - 2.2.3
-
-branches:
-  only:
-    - master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ActiveRecord + PostgreSQL Earthdistance [![Build Status](https://travis-ci.org/diogob/activerecord-postgres-earthdistance.svg?branch=master)](https://travis-ci.org/diogob/activerecord-postgres-earthdistance) [![Code Climate](https://codeclimate.com/github/diogob/activerecord-postgres-earthdistance/badges/gpa.svg)](https://codeclimate.com/github/diogob/activerecord-postgres-earthdistance)
+# ActiveRecord + PostgreSQL Earthdistance [![Build Status](https://github.com/diogob/activerecord-postgres-earthdistance/actions/workflows/test/badge.svg)](https://github.com/diogob/activerecord-postgres-earthdistance/actions) [![Code Climate](https://codeclimate.com/github/diogob/activerecord-postgres-earthdistance/badges/gpa.svg)](https://codeclimate.com/github/diogob/activerecord-postgres-earthdistance)
 
 Check distances with latitude and longitude using PostgreSQL special indexes.
 This gem enables your model to query the database using the earthdistance extension. This should be much faster than using trigonometry functions over standard indexes.

--- a/gemfiles/activerecord-4.2.gemfile
+++ b/gemfiles/activerecord-4.2.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gemspec path: '..'
+
+gem "activerecord", "~> 4.2.0"
+gem "pg", "~> 0.15"

--- a/gemfiles/activerecord-5.0.gemfile
+++ b/gemfiles/activerecord-5.0.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gemspec path: '..'
+
+gem "activerecord", "~> 5.0.0"

--- a/gemfiles/activerecord-5.1.gemfile
+++ b/gemfiles/activerecord-5.1.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gemspec path: '..'
+
+gem "activerecord", "~> 5.1.0"

--- a/gemfiles/activerecord-5.2.gemfile
+++ b/gemfiles/activerecord-5.2.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gemspec path: '..'
+
+gem "activerecord", "~> 5.2.0"

--- a/gemfiles/activerecord-6.0.gemfile
+++ b/gemfiles/activerecord-6.0.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gemspec path: '..'
+
+gem "activerecord", "~> 6.0.0"

--- a/gemfiles/activerecord-6.1.gemfile
+++ b/gemfiles/activerecord-6.1.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gemspec path: '..'
+
+gem "activerecord", "~> 6.1.0"

--- a/gemfiles/activerecord-7.0.gemfile
+++ b/gemfiles/activerecord-7.0.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gemspec path: '..'
+
+gem "activerecord", "~> 7.0.0"


### PR DESCRIPTION
Travis stopped building for open source in June 2021.

I'm testing Ruby 2.4+ and activerecord 4.2+, using Rails's CI as a guide for which Ruby versions to test each activerecord version on. While this gem's gemspec supports Ruby 1.8+ and activerecord 3.1+, the older Ruby versions aren't installable on GitHub Actions, or crash, so they're not tested. Given their age, support should likely be dropped for them as compatibility will no longer be ensured if CI isn't testing them.

I'm using PostgreSQL 11 as v12 and newer use a larger precision for the distance returned when using `selecting_distance_from`, which fails a spec. Ideally the spec should be updated to not assert a specific precision, allowing larger precisions.

This'll highlight a regression in `selecting_distance_from` on activerecord 6.1+ when called directly on a geolocated model, as opposed to through a geolocated model, which I'll address in a follow up PR.

Thanks for the existing work on this gem!

Note: I suspect CI wont actually run until after this is merged, then it should run on the resulting merge commit, as well as future PRs. You can see the results of the CI run on my fork:
https://github.com/cgunther/activerecord-postgres-earthdistance/actions/runs/3254382136