### PR TITLE
Only join to `through_table` from `selecting_distance_from` when there is one

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -2,9 +2,9 @@ module ActiveRecordPostgresEarthdistance
   MILES_TO_METERS_FACTOR = 1609.344
   module ActsAsGeolocated
     extend ActiveSupport::Concern
-    
 
-    module ClassMethods  
+
+    module ClassMethods
       def acts_as_geolocated(options = {})
         begin
           if table_exists?
@@ -95,7 +95,7 @@ module ActiveRecordPostgresEarthdistance
   module QueryMethods
     def selecting_distance_from(lat, lng, name = "distance", include_default_columns = true)
       clone.tap do |relation|
-        relation.joins!(through_table)
+        relation.joins!(through_table) if through_table
         values = []
         if relation.select_values.empty? && include_default_columns
           values << relation.arel_table[Arel.star]


### PR DESCRIPTION
Prior to Rails 6.1, the arguments to `joins!` were compacted, so if you called `selecting_distance_from` directly on the geolocated model where `through_table` was `nil`, it'd be compacted away and a join wouldn't actually be attempted.

Since Rails 6.1, the arguments to `joins!` are no longer compacted, so a join will be attempted to `nil` in such a case, leading to an error.

Now we'll only join to the `through_table` if there actually is one.

Here's the relevant Rails commit:
https://github.com/rails/rails/commit/6038755377533ca8f779cc9158f4a8708de166b0

Once #47 is merged, this can be rebased to show it'll fix the failing specs.