### PR TITLE
Maintain previously selected columns when calling `selecting_distance_from`

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -107,7 +107,7 @@ module ActiveRecordPostgresEarthdistance
 
         values << distances
 
-        relation.select_values = values
+        relation.select_values |= values
       end
     end
   end

--- a/spec/act_as_geolocated_spec.rb
+++ b/spec/act_as_geolocated_spec.rb
@@ -78,13 +78,13 @@ describe "ActiveRecord::Base.act_as_geolocated" do
 
     subject { Place.within_box(test_data[:radius], test_data[:lat], test_data[:lng]) }
 
-    before(:all) { 
+    before(:all) {
       Place.acts_as_geolocated distance_unit: :miles
-      @place = Place.create!(lat: -30.0277041, lng: -51.2287346) 
+      @place = Place.create!(lat: -30.0277041, lng: -51.2287346)
     }
-    after(:all) { 
+    after(:all) {
       Place.acts_as_geolocated
-      @place.destroy 
+      @place.destroy
     }
 
     context "when query with null data" do
@@ -93,7 +93,7 @@ describe "ActiveRecord::Base.act_as_geolocated" do
 
     context "when query for the exact same point with radius 0" do
       let(:test_data) { { lat: -30.0277041, lng: -51.2287346, radius: 0 } }
-      
+
       it { is_expected.to eq [@place] }
     end
 
@@ -354,6 +354,15 @@ describe "ActiveRecord::Base.act_as_geolocated" do
       end
 
       context "when selecting distance" do
+        it { is_expected.to respond_to :distance }
+      end
+    end
+
+    context "with explicit columns selected" do
+      subject { Place.select('data AS special_data').selecting_distance_from(current_location[:lat], current_location[:lng]).first }
+
+      context "when selecting distance" do
+        it { is_expected.to respond_to :special_data }
         it { is_expected.to respond_to :distance }
       end
     end


### PR DESCRIPTION
Previously, if you called `Model.select('my_column').selecting_distance_from`, those columns you explicitly selected would be lost in the resulting query as `selecting_distance_from` completely replaced the selected columns.

Now, `selecting_distance_from` will append (set union) to the previously selected columns.