### PR TITLE
Respect distance units when ordering by distance

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -47,6 +47,9 @@ module ActiveRecordPostgresEarthdistance
 
       def order_by_distance(lat, lng, order = "ASC")
         earth_distance = Utils.earth_distance(through_table_klass, lat, lng)
+        earth_distance = Arel::Nodes::Multiplication.new(
+          Utils.quote_value(1 / MILES_TO_METERS_FACTOR), earth_distance
+        ) if distance_unit === :miles
         joins(through_table).order(Arel.sql("#{earth_distance.to_sql} #{order}"))
       end
 

--- a/spec/act_as_geolocated_spec.rb
+++ b/spec/act_as_geolocated_spec.rb
@@ -379,6 +379,19 @@ describe "ActiveRecord::Base.act_as_geolocated" do
     context "when selecting distance" do
       let(:current_location) { { lat: 52.229676, lng: 21.012229 } } # Warsaw
       it { is_expected.to eq ["Amsterdam", 680.410076641856] }
+
+      context "and selecting distinct and ordering by distance" do
+        subject do
+          Place
+            .order_by_distance(current_location[:lat], current_location[:lng])
+            .selecting_distance_from(current_location[:lat], current_location[:lng])
+            .distinct
+            .first
+            .try { |p| [p.data, p.distance.to_f] }
+        end
+
+        it { is_expected.to eq ["Amsterdam", 680.410076641856] }
+      end
     end
 
     context "through table" do


### PR DESCRIPTION
While the unit shouldn't change the result, if you order and select with a distinct call (ie. `Model.distinct.selecting_distance_from(...).order_by_distance(...)`), Postgres requires all ordering values to also be selected.

Previously, in such a case, we'd be selecting by miles when that was the configured unit, but then ordering by meters, which Postres didn't like.

Now, we'll both select miles and order by miles when configured as such.