### PR TITLE
Rescue ActiveRecord::ConnectionNotEstablished

### DIFF
--- a/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
+++ b/lib/activerecord-postgres-earthdistance/acts_as_geolocated.rb
@@ -18,6 +18,7 @@ module ActiveRecordPostgresEarthdistance
             puts "[WARNING] table #{table_name} doesn't exist, acts_as_geolocated won't work. Skip this warning if you are running db migration"
           end
         rescue ActiveRecord::NoDatabaseError
+        rescue ActiveRecord::ConnectionNotEstablished
         rescue PG::ConnectionBad
         end
       end


### PR DESCRIPTION
In container builds, there may not be a database present at all, raising `ActiveRecord::ConnectionNotEstablished`. This catches the error, allowing activities like asset precompilation in container builds without access to a database instance.